### PR TITLE
Revert "fix(container): update talos group ( v1.13.2 ➔ v1.13.3 )"

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   talos:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-    version: v1.13.3
+    version: v1.13.2
   policy:
     rebootMode: powercycle
   healthChecks:

--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -49,7 +49,7 @@ machine:
   install:
     diskSelector:
       model: Samsung SSD 870
-    image: factory.talos.dev/metal-installer/1363def95c4c8cb47ffd79fe4ab94910fccb5aee790d205f9280834779229a1b:v1.13.3
+    image: factory.talos.dev/metal-installer/1363def95c4c8cb47ffd79fe4ab94910fccb5aee790d205f9280834779229a1b:v1.13.2
     wipe: false
   kernel:
     modules:


### PR DESCRIPTION
Revert "fix(container): update talos group ( v1.13.2 ➔ v1.13.3 )"

Bug: 1.13.3 fails to start control plane static pods